### PR TITLE
Add conference room selection and calendar reservation UI

### DIFF
--- a/calendar.js
+++ b/calendar.js
@@ -1,0 +1,126 @@
+(function () {
+  const calendarSlots = document.querySelectorAll('[data-slot]');
+  const modal = document.getElementById('reservationModal');
+  const form = document.getElementById('reservationForm');
+  const dateInput = document.getElementById('reservationDateTime');
+  const noteInput = document.getElementById('reservationNote');
+  const closeButtons = document.querySelectorAll('[data-close-modal]');
+  const messageArea = document.querySelector('.calendar-message');
+  const refreshButton = document.querySelector('[data-calendar-refresh]');
+
+  if (!form || !modal || !dateInput) {
+    return;
+  }
+
+  const endpoint = form.dataset.endpoint || form.getAttribute('action') || 'reservation_calendar_api.php';
+  const room = form.dataset.room || '';
+
+  function setMessage(text, isError = false) {
+    if (!messageArea) {
+      return;
+    }
+    messageArea.textContent = text;
+    messageArea.classList.toggle('calendar-message--error', isError);
+    if (text) {
+      messageArea.classList.add('is-visible');
+    } else {
+      messageArea.classList.remove('is-visible');
+    }
+  }
+
+  function openModal(datetimeValue) {
+    dateInput.value = datetimeValue || '';
+    noteInput.value = '';
+    modal.classList.add('is-open');
+    modal.setAttribute('aria-hidden', 'false');
+    window.setTimeout(() => {
+      dateInput.focus();
+    }, 50);
+  }
+
+  function closeModal() {
+    modal.classList.remove('is-open');
+    modal.setAttribute('aria-hidden', 'true');
+  }
+
+  calendarSlots.forEach((slot) => {
+    slot.addEventListener('click', () => {
+      const status = slot.dataset.status;
+      if (status !== 'available') {
+        return;
+      }
+      const datetime = slot.dataset.datetime || '';
+      openModal(datetime);
+    });
+  });
+
+  closeButtons.forEach((button) => {
+    button.addEventListener('click', () => {
+      closeModal();
+    });
+  });
+
+  if (refreshButton) {
+    refreshButton.addEventListener('click', () => {
+      window.location.reload();
+    });
+  }
+
+  modal.addEventListener('click', (event) => {
+    if (event.target && event.target.matches('.reservation-modal__overlay')) {
+      closeModal();
+    }
+  });
+
+  form.addEventListener('submit', async (event) => {
+    event.preventDefault();
+    const reservedAt = dateInput.value.trim();
+    const note = noteInput.value.trim();
+    if (!reservedAt) {
+      setMessage('予約日時を入力してください。', true);
+      return;
+    }
+
+    const submitButton = form.querySelector('button[type="submit"]');
+    if (submitButton) {
+      submitButton.disabled = true;
+      submitButton.textContent = '保存中...';
+    }
+    setMessage('予約を登録しています...');
+
+    try {
+      const response = await fetch(endpoint, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Requested-With': 'XMLHttpRequest',
+        },
+        body: JSON.stringify({
+          room,
+          reserved_at: reservedAt,
+          note,
+        }),
+      });
+
+      const payload = await response.json();
+      if (!response.ok || !payload.success) {
+        const message = payload && payload.error ? payload.error : '予約の登録に失敗しました。';
+        setMessage(message, true);
+        return;
+      }
+
+      setMessage(payload.message || '予約を登録しました。');
+      closeModal();
+      window.setTimeout(() => {
+        window.location.reload();
+      }, 1200);
+    } catch (error) {
+      setMessage('通信中にエラーが発生しました。時間をおいて再度お試しください。', true);
+    } finally {
+      if (submitButton) {
+        submitButton.disabled = false;
+        submitButton.textContent = '保存';
+      }
+    }
+  });
+})();

--- a/me.php
+++ b/me.php
@@ -24,7 +24,7 @@ $displayName = $user['display_name'] ?? '';
     <div class="user-home-header__inner">
       <div class="user-menu">
         <span class="user-menu__label">ようこそ、<?= htmlspecialchars($displayName, ENT_QUOTES, 'UTF-8') ?>さん（一般ユーザー）</span>
-        <a class="user-menu__link" href="reservations.php">会議室を予約</a>
+        <a class="user-menu__link" href="reservations_select.php">会議室を予約</a>
         <a class="user-menu__link" href="logout.php">ログアウト</a>
       </div>
       <h1 class="user-home-title">高橋建設</h1>
@@ -36,7 +36,7 @@ $displayName = $user['display_name'] ?? '';
     <section class="user-home-actions" aria-labelledby="quickLinks">
       <h2 id="quickLinks" class="user-home-section-title">クイックアクセス</h2>
       <div class="user-home-buttons">
-        <a class="user-home-button user-home-button--reserve" href="reservations.php">会議室を予約</a>
+        <a class="user-home-button user-home-button--reserve" href="reservations_select.php">会議室を予約</a>
         <a class="user-home-button user-home-button--important" href="form.php">重要なお知らせを見る</a>
         <a class="user-home-button user-home-button--other" href="sonota.php">その他のお知らせを見る</a>
       </div>

--- a/reservation_calendar_api.php
+++ b/reservation_calendar_api.php
@@ -1,0 +1,113 @@
+<?php
+require_once __DIR__ . '/auth.php';
+require_once __DIR__ . '/database.php';
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    header('Allow: POST');
+    header('Content-Type: application/json; charset=UTF-8');
+    echo json_encode(['success' => false, 'error' => 'Method not allowed.']);
+    exit;
+}
+
+try {
+    requireLogin();
+} catch (Throwable $exception) {
+    http_response_code(401);
+    header('Content-Type: application/json; charset=UTF-8');
+    echo json_encode(['success' => false, 'error' => '認証が必要です。']);
+    exit;
+}
+
+$user = getAuthenticatedUser();
+$displayName = $user['display_name'] ?? '';
+
+$input = [];
+$contentType = $_SERVER['CONTENT_TYPE'] ?? '';
+if (stripos($contentType, 'application/json') !== false) {
+    $raw = file_get_contents('php://input');
+    $decoded = json_decode($raw, true);
+    if (is_array($decoded)) {
+        $input = $decoded;
+    }
+} else {
+    $input = $_POST;
+}
+
+$validRooms = ['large' => '大会議室', 'small' => '小会議室'];
+$room = isset($input['room']) ? (string) $input['room'] : '';
+$reservedAtInput = isset($input['reserved_at']) ? (string) $input['reserved_at'] : '';
+$note = isset($input['note']) ? trim((string) $input['note']) : '';
+
+$errors = [];
+if (!isset($validRooms[$room])) {
+    $errors[] = '会議室の指定が正しくありません。';
+}
+
+$timezone = new DateTimeZone('Asia/Tokyo');
+$reservedAt = null;
+if ($reservedAtInput === '') {
+    $errors[] = '予約日時を入力してください。';
+} else {
+    $reservedAt = DateTimeImmutable::createFromFormat('Y-m-d\TH:i', $reservedAtInput, $timezone);
+    if (!$reservedAt) {
+        $alt = DateTimeImmutable::createFromFormat('Y-m-d H:i:s', $reservedAtInput, $timezone);
+        if ($alt) {
+            $reservedAt = $alt;
+        }
+    }
+    if (!$reservedAt) {
+        $errors[] = '予約日時の形式が正しくありません。';
+    }
+}
+
+if ($reservedAt instanceof DateTimeImmutable) {
+    $now = new DateTimeImmutable('now', $timezone);
+    if ($reservedAt < $now->modify('-1 hour')) {
+        $errors[] = '過去の日時は予約できません。';
+    }
+}
+
+if ($errors) {
+    http_response_code(422);
+    header('Content-Type: application/json; charset=UTF-8');
+    echo json_encode(['success' => false, 'error' => implode('\n', $errors)]);
+    exit;
+}
+
+try {
+    $pdo = getPdo();
+    $stmt = $pdo->prepare('INSERT INTO reservations (room, reserved_at, user_id, reserved_for, note) VALUES (:room, :reserved_at, :user_id, :reserved_for, :note)');
+    $stmt->execute([
+        ':room' => $room,
+        ':reserved_at' => $reservedAt->format('Y-m-d H:i:s'),
+        ':user_id' => $user['id'],
+        ':reserved_for' => $displayName !== '' ? $displayName : '利用者',
+        ':note' => $note !== '' ? $note : null,
+    ]);
+
+    header('Content-Type: application/json; charset=UTF-8');
+    echo json_encode([
+        'success' => true,
+        'reservation' => [
+            'room' => $room,
+            'reserved_at' => $reservedAt->format('Y-m-d\TH:i'),
+            'reserved_for' => $displayName !== '' ? $displayName : '利用者',
+            'note' => $note,
+        ],
+        'message' => sprintf('%sを%sに予約しました。', $validRooms[$room], $reservedAt->format('Y/m/d H:i')),
+    ]);
+} catch (PDOException $exception) {
+    $code = (int) $exception->getCode();
+    $message = '予約の登録に失敗しました。時間をおいて再度お試しください。';
+    if ($code === 23000) {
+        $message = '指定した時間帯はすでに予約されています。別の時間を選択してください。';
+    }
+    http_response_code(409);
+    header('Content-Type: application/json; charset=UTF-8');
+    echo json_encode(['success' => false, 'error' => $message]);
+} catch (Throwable $exception) {
+    http_response_code(500);
+    header('Content-Type: application/json; charset=UTF-8');
+    echo json_encode(['success' => false, 'error' => '予期しないエラーが発生しました。']);
+}

--- a/reservations_select.php
+++ b/reservations_select.php
@@ -1,0 +1,63 @@
+<?php
+require_once __DIR__ . '/auth.php';
+requireLogin();
+
+$user = getAuthenticatedUser();
+$displayName = $user['display_name'] ?? '';
+$roleLabel = ($user['role'] ?? '') === 'admin' ? '管理者' : '一般ユーザー';
+
+$roomPages = [
+    'large' => [
+        'label' => '大会議室',
+        'description' => '最大20名まで利用できる広々とした会議スペースです。',
+        'link' => 'room_calendar.php?room=large',
+    ],
+    'small' => [
+        'label' => '小会議室',
+        'description' => '4〜6名での打ち合わせに最適なコンパクトな会議室です。',
+        'link' => 'room_calendar.php?room=small',
+    ],
+];
+?>
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>会議室を選択 | 高橋建設</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body class="page-room-selection">
+  <header class="selection-header">
+    <div class="selection-header__inner">
+      <a class="back-link" href="me.php">&larr; ホームに戻る</a>
+      <div class="selection-header__title-area">
+        <h1 class="selection-title">会議室予約</h1>
+        <p class="selection-subtitle">利用したい会議室を選んでください。</p>
+      </div>
+      <div class="user-menu">
+        <span class="user-menu__label">ようこそ、<?= htmlspecialchars($displayName, ENT_QUOTES, 'UTF-8') ?>さん（<?= htmlspecialchars($roleLabel, ENT_QUOTES, 'UTF-8') ?>）</span>
+        <a class="user-menu__link" href="logout.php">ログアウト</a>
+      </div>
+    </div>
+  </header>
+
+  <main class="selection-main" aria-labelledby="roomSelectionHeading">
+    <h2 id="roomSelectionHeading" class="selection-main__title">会議室を選択</h2>
+    <div class="room-options" role="list">
+      <?php foreach ($roomPages as $roomKey => $room): ?>
+        <a class="room-option" role="listitem" href="<?= htmlspecialchars($room['link'], ENT_QUOTES, 'UTF-8') ?>">
+          <div class="room-option__icon" aria-hidden="true">
+            <?= $roomKey === 'large' ? '🏢' : '📌' ?>
+          </div>
+          <div class="room-option__content">
+            <h3 class="room-option__title"><?= htmlspecialchars($room['label'], ENT_QUOTES, 'UTF-8') ?></h3>
+            <p class="room-option__description"><?= htmlspecialchars($room['description'], ENT_QUOTES, 'UTF-8') ?></p>
+          </div>
+          <div class="room-option__chevron" aria-hidden="true">&rarr;</div>
+        </a>
+      <?php endforeach; ?>
+    </div>
+  </main>
+</body>
+</html>

--- a/room_calendar.php
+++ b/room_calendar.php
@@ -1,0 +1,223 @@
+<?php
+require_once __DIR__ . '/auth.php';
+require_once __DIR__ . '/database.php';
+requireLogin();
+
+$user = getAuthenticatedUser();
+$displayName = $user['display_name'] ?? '';
+$roleLabel = ($user['role'] ?? '') === 'admin' ? '管理者' : '一般ユーザー';
+
+$validRooms = [
+    'large' => '大会議室',
+    'small' => '小会議室',
+];
+
+$room = isset($_GET['room']) ? (string) $_GET['room'] : '';
+if (!isset($validRooms[$room])) {
+    http_response_code(404);
+    echo '<!DOCTYPE html><html lang="ja"><head><meta charset="UTF-8"><title>会議室が見つかりません</title></head><body><p>指定された会議室は存在しません。</p></body></html>';
+    exit;
+}
+
+$timezone = new DateTimeZone('Asia/Tokyo');
+$today = new DateTimeImmutable('today', $timezone);
+$weekStartParam = isset($_GET['week_start']) ? (string) $_GET['week_start'] : '';
+$baseDate = $today;
+if ($weekStartParam !== '') {
+    $candidate = DateTimeImmutable::createFromFormat('Y-m-d', $weekStartParam, $timezone);
+    if ($candidate instanceof DateTimeImmutable) {
+        $baseDate = $candidate;
+    }
+}
+
+$weekStart = $baseDate->setTime(0, 0)->modify('monday this week');
+$weekEnd = $weekStart->modify('+7 days');
+
+$days = [];
+for ($i = 0; $i < 7; $i++) {
+    $day = $weekStart->modify("+{$i} days");
+    $days[] = $day;
+}
+
+$timeSlots = [];
+for ($hour = 8; $hour <= 18; $hour++) {
+    $timeSlots[] = sprintf('%02d:00', $hour);
+}
+
+$reservationMap = [];
+$errorMessage = '';
+try {
+    $pdo = getPdo();
+    $stmt = $pdo->prepare('SELECT reserved_at, reserved_for, note FROM reservations WHERE room = :room AND reserved_at >= :start AND reserved_at < :end ORDER BY reserved_at');
+    $stmt->execute([
+        ':room' => $room,
+        ':start' => $weekStart->format('Y-m-d H:i:s'),
+        ':end' => $weekEnd->format('Y-m-d H:i:s'),
+    ]);
+    foreach ($stmt->fetchAll() as $row) {
+        $reservedAt = DateTimeImmutable::createFromFormat('Y-m-d H:i:s', $row['reserved_at'], $timezone);
+        if (!$reservedAt) {
+            continue;
+        }
+        $slotKey = $reservedAt->format('Y-m-d\TH:i');
+        $reservationMap[$slotKey] = [
+            'reserved_for' => $row['reserved_for'],
+            'note' => $row['note'] ?? '',
+        ];
+    }
+} catch (Throwable $exception) {
+    $errorMessage = '予約情報を取得できませんでした。時間をおいて再度お試しください。';
+}
+
+function formatDayLabel(DateTimeImmutable $date): string
+{
+    static $weekdayMap = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+    return $date->format('n/j') . ' (' . $weekdayMap[(int) $date->format('w')] . ')';
+}
+
+function formatRangeLabel(DateTimeImmutable $start, DateTimeImmutable $end): string
+{
+    static $weekdayMap = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+    $endPrev = $end->modify('-1 day');
+    return $start->format('Y/m/d') . ' (' . $weekdayMap[(int) $start->format('w')] . ') ~ ' . $endPrev->format('Y/m/d') . ' (' . $weekdayMap[(int) $endPrev->format('w')] . ')';
+}
+
+$weekRangeLabel = formatRangeLabel($weekStart, $weekEnd);
+$prevWeekUrl = 'room_calendar.php?room=' . urlencode($room) . '&week_start=' . $weekStart->modify('-7 days')->format('Y-m-d');
+$nextWeekUrl = 'room_calendar.php?room=' . urlencode($room) . '&week_start=' . $weekStart->modify('+7 days')->format('Y-m-d');
+$currentWeekUrl = 'room_calendar.php?room=' . urlencode($room);
+
+$todayKey = $today->format('Y-m-d');
+?>
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title><?= htmlspecialchars($validRooms[$room], ENT_QUOTES, 'UTF-8') ?>の予約カレンダー | 高橋建設</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body class="page-room-calendar">
+  <header class="calendar-header">
+    <div class="calendar-header__inner">
+      <div class="calendar-header__breadcrumbs">
+        <a class="back-link" href="reservations_select.php">&larr; 会議室選択に戻る</a>
+      </div>
+      <div class="calendar-header__title-area">
+        <h1 class="calendar-title"><?= htmlspecialchars($validRooms[$room], ENT_QUOTES, 'UTF-8') ?>の予約カレンダー</h1>
+        <p class="calendar-range" aria-live="polite"><?= htmlspecialchars($weekRangeLabel, ENT_QUOTES, 'UTF-8') ?></p>
+      </div>
+      <div class="user-menu">
+        <span class="user-menu__label">ようこそ、<?= htmlspecialchars($displayName, ENT_QUOTES, 'UTF-8') ?>さん（<?= htmlspecialchars($roleLabel, ENT_QUOTES, 'UTF-8') ?>）</span>
+        <a class="user-menu__link" href="logout.php">ログアウト</a>
+      </div>
+    </div>
+  </header>
+
+  <main class="calendar-main">
+    <section class="calendar-controls" aria-label="週の切り替え">
+      <div class="calendar-controls__buttons">
+        <a class="calendar-nav-button" href="<?= htmlspecialchars($prevWeekUrl, ENT_QUOTES, 'UTF-8') ?>">前の週</a>
+        <a class="calendar-nav-button calendar-nav-button--today" href="<?= htmlspecialchars($currentWeekUrl, ENT_QUOTES, 'UTF-8') ?>">今週</a>
+        <a class="calendar-nav-button" href="<?= htmlspecialchars($nextWeekUrl, ENT_QUOTES, 'UTF-8') ?>">次の週</a>
+      </div>
+      <button type="button" class="calendar-nav-button calendar-nav-button--refresh" data-calendar-refresh>最新の状態に更新</button>
+    </section>
+
+    <?php if ($errorMessage !== ''): ?>
+      <p class="calendar-alert" role="alert"><?= htmlspecialchars($errorMessage, ENT_QUOTES, 'UTF-8') ?></p>
+    <?php endif; ?>
+
+    <div class="calendar-wrapper">
+      <table class="calendar-table" aria-describedby="calendarLegend">
+        <thead>
+          <tr>
+            <th scope="col" class="calendar-table__time">時間</th>
+            <?php foreach ($days as $day): ?>
+              <?php $isToday = $day->format('Y-m-d') === $todayKey; ?>
+              <th scope="col" class="calendar-table__day<?= $isToday ? ' is-today' : '' ?>">
+                <?= htmlspecialchars(formatDayLabel($day), ENT_QUOTES, 'UTF-8') ?>
+              </th>
+            <?php endforeach; ?>
+          </tr>
+        </thead>
+        <tbody>
+          <?php foreach ($timeSlots as $slot): ?>
+            <tr>
+              <th scope="row" class="calendar-table__time"><?= htmlspecialchars($slot, ENT_QUOTES, 'UTF-8') ?></th>
+              <?php foreach ($days as $day): ?>
+                <?php
+                  $slotDateTime = $day->format('Y-m-d') . 'T' . $slot;
+                  $reservation = $reservationMap[$slotDateTime] ?? null;
+                  $cellClasses = 'calendar-cell';
+                  if ($reservation) {
+                      $cellClasses .= ' calendar-cell--reserved';
+                  } else {
+                      $cellClasses .= ' calendar-cell--available';
+                  }
+                  if ($day->format('Y-m-d') === $todayKey) {
+                      $cellClasses .= ' is-today';
+                  }
+                ?>
+                <td class="<?= $cellClasses ?>">
+                  <?php if ($reservation): ?>
+                    <?php
+                      $initial = mb_substr($reservation['reserved_for'], 0, 1, 'UTF-8');
+                      $note = $reservation['note'] !== '' ? $reservation['note'] : $reservation['reserved_for'];
+                    ?>
+                    <div class="reservation-chip" title="<?= htmlspecialchars($reservation['reserved_for'], ENT_QUOTES, 'UTF-8') ?>">
+                      <span class="reservation-chip__icon" aria-hidden="true"><?= htmlspecialchars($initial, ENT_QUOTES, 'UTF-8') ?></span>
+                      <div class="reservation-chip__content">
+                        <span class="reservation-chip__title"><?= htmlspecialchars($note, ENT_QUOTES, 'UTF-8') ?></span>
+                        <span class="reservation-chip__meta">担当：<?= htmlspecialchars($reservation['reserved_for'], ENT_QUOTES, 'UTF-8') ?></span>
+                      </div>
+                    </div>
+                  <?php else: ?>
+                    <button
+                      type="button"
+                      class="calendar-slot"
+                      data-slot
+                      data-status="available"
+                      data-room="<?= htmlspecialchars($room, ENT_QUOTES, 'UTF-8') ?>"
+                      data-datetime="<?= htmlspecialchars($slotDateTime, ENT_QUOTES, 'UTF-8') ?>"
+                      aria-label="<?= htmlspecialchars($day->format('n月j日'), ENT_QUOTES, 'UTF-8') ?>の<?= htmlspecialchars($slot, ENT_QUOTES, 'UTF-8') ?>を予約する"
+                    >
+                      ○
+                    </button>
+                  <?php endif; ?>
+                </td>
+              <?php endforeach; ?>
+            </tr>
+          <?php endforeach; ?>
+        </tbody>
+      </table>
+      <p id="calendarLegend" class="calendar-legend">○の枠をクリックすると予約を登録できます。青いカードは既に予約済みの時間です。</p>
+    </div>
+
+    <div class="calendar-message" role="status" aria-live="polite"></div>
+  </main>
+
+  <div class="reservation-modal" id="reservationModal" aria-hidden="true" role="dialog" aria-modal="true">
+    <div class="reservation-modal__overlay" data-close-modal></div>
+    <div class="reservation-modal__content">
+      <h2 class="reservation-modal__title">予約の作成</h2>
+      <form id="reservationForm" class="reservation-form" data-room="<?= htmlspecialchars($room, ENT_QUOTES, 'UTF-8') ?>" data-endpoint="reservation_calendar_api.php">
+        <label class="reservation-form__field">
+          <span class="reservation-form__label">日時</span>
+          <input type="datetime-local" id="reservationDateTime" name="reserved_at" required>
+        </label>
+        <label class="reservation-form__field">
+          <span class="reservation-form__label">メモ</span>
+          <textarea id="reservationNote" name="note" rows="3" placeholder="打ち合わせ名や共有事項を入力してください"></textarea>
+        </label>
+        <div class="reservation-form__actions">
+          <button type="button" class="reservation-button reservation-button--sub" data-close-modal>閉じる</button>
+          <button type="submit" class="reservation-button">保存</button>
+        </div>
+      </form>
+    </div>
+  </div>
+
+  <script src="calendar.js" defer></script>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -399,6 +399,555 @@ main {
   line-height: 1.6;
 }
 
+/* =============================
+   会議室選択ページ
+   ============================= */
+.page-room-selection {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background: linear-gradient(135deg, #f4f7fb 0%, #eef2ff 100%);
+}
+
+.selection-header {
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 6px 20px rgba(21, 101, 192, 0.12);
+}
+
+.selection-header__inner {
+  width: 100%;
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 28px 16px;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 16px;
+  align-items: center;
+}
+
+.selection-header__title-area {
+  grid-column: 1 / -1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.35rem;
+  text-align: center;
+}
+
+.selection-title {
+  margin: 0;
+  font-size: clamp(2rem, 3vw, 2.6rem);
+  color: #1a237e;
+  letter-spacing: 0.06em;
+}
+
+.selection-subtitle {
+  margin: 0;
+  font-size: 1.05rem;
+  color: #546e7a;
+}
+
+.selection-main {
+  flex: 1;
+  width: 100%;
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 48px 16px 72px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 32px;
+}
+
+.selection-main__title {
+  margin: 0;
+  font-size: clamp(1.75rem, 2.5vw, 2.2rem);
+  color: #1a237e;
+  letter-spacing: 0.05em;
+}
+
+.room-options {
+  width: 100%;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 24px;
+}
+
+.room-option {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 16px;
+  padding: 24px;
+  border-radius: 20px;
+  border: 3px solid #f6c453;
+  background: #fffef6;
+  box-shadow: 0 8px 24px rgba(246, 196, 83, 0.18);
+  font-weight: bold;
+  color: #37474f;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.room-option:hover,
+.room-option:focus {
+  transform: translateY(-4px);
+  box-shadow: 0 14px 32px rgba(21, 101, 192, 0.18);
+  border-color: #f7ca65;
+}
+
+.room-option__icon {
+  width: 56px;
+  height: 56px;
+  border-radius: 16px;
+  background: #fff4cd;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 2rem;
+}
+
+.room-option__content {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.room-option__title {
+  margin: 0;
+  font-size: 1.4rem;
+  color: #1a237e;
+}
+
+.room-option__description {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: normal;
+  color: #607d8b;
+}
+
+.room-option__chevron {
+  font-size: 1.75rem;
+  color: #1a237e;
+}
+
+@media (max-width: 640px) {
+  .selection-header__inner {
+    grid-template-columns: 1fr;
+    text-align: center;
+  }
+
+  .selection-header__title-area {
+    grid-column: 1;
+  }
+
+  .room-option {
+    grid-template-columns: 1fr;
+    text-align: center;
+  }
+
+  .room-option__icon {
+    margin: 0 auto;
+  }
+
+  .room-option__chevron {
+    display: none;
+  }
+}
+
+/* =============================
+   会議室カレンダーページ
+   ============================= */
+.page-room-calendar {
+  min-height: 100vh;
+  background: #f3f6fb;
+  display: flex;
+  flex-direction: column;
+}
+
+.calendar-header {
+  background: #fff;
+  box-shadow: 0 4px 16px rgba(26, 35, 126, 0.08);
+}
+
+.calendar-header__inner {
+  width: 100%;
+  max-width: 1040px;
+  margin: 0 auto;
+  padding: 28px 16px;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 16px;
+  align-items: center;
+}
+
+.calendar-header__title-area {
+  grid-column: 1 / -1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  text-align: center;
+}
+
+.calendar-title {
+  margin: 0;
+  font-size: clamp(2rem, 3vw, 2.6rem);
+  color: #1a237e;
+  letter-spacing: 0.04em;
+}
+
+.calendar-range {
+  margin: 0;
+  font-size: 1.05rem;
+  color: #5c6bc0;
+}
+
+.calendar-main {
+  width: 100%;
+  max-width: 1040px;
+  margin: 0 auto;
+  padding: 32px 16px 72px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.calendar-controls {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: center;
+}
+
+.calendar-controls__buttons {
+  display: inline-flex;
+  gap: 12px;
+}
+
+.calendar-nav-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.55rem 1.5rem;
+  border-radius: 999px;
+  background: #e3f2fd;
+  color: #1565c0;
+  font-weight: bold;
+  font-size: 0.95rem;
+  border: none;
+  cursor: pointer;
+  transition: background-color 0.2s ease, transform 0.2s ease;
+}
+
+.calendar-nav-button:hover,
+.calendar-nav-button:focus {
+  background: #bbdefb;
+  transform: translateY(-1px);
+}
+
+.calendar-nav-button--today {
+  background: #c5cae9;
+  color: #283593;
+}
+
+.calendar-nav-button--refresh {
+  background: #ede7f6;
+  color: #512da8;
+}
+
+.calendar-wrapper {
+  overflow-x: auto;
+  background: #fff;
+  border-radius: 20px;
+  box-shadow: 0 10px 28px rgba(63, 81, 181, 0.12);
+  padding: 24px;
+}
+
+.calendar-table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  min-width: 720px;
+}
+
+.calendar-table__time {
+  position: sticky;
+  left: 0;
+  background: #fff;
+  font-weight: 600;
+  color: #3949ab;
+  padding: 0.85rem 1rem;
+  border-bottom: 1px solid #e8eaf6;
+}
+
+.calendar-table__day {
+  text-align: center;
+  font-weight: 600;
+  color: #3949ab;
+  padding: 0.85rem 0.5rem;
+  border-bottom: 1px solid #e8eaf6;
+}
+
+.calendar-table__day.is-today {
+  color: #1a237e;
+  background: rgba(197, 202, 233, 0.35);
+}
+
+.calendar-cell {
+  height: 72px;
+  padding: 8px;
+  border-bottom: 1px solid #edf2ff;
+  border-right: 1px solid #edf2ff;
+}
+
+.calendar-cell.is-today {
+  background: rgba(227, 242, 253, 0.35);
+}
+
+.calendar-cell:last-child {
+  border-right: none;
+}
+
+.calendar-cell--available {
+  text-align: center;
+}
+
+.calendar-slot {
+  width: 100%;
+  height: 100%;
+  border-radius: 16px;
+  border: 2px dashed #ef5350;
+  background: rgba(255, 255, 255, 0.8);
+  color: #ef5350;
+  font-size: 1.4rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+}
+
+.calendar-slot:hover,
+.calendar-slot:focus {
+  transform: translateY(-2px);
+  background: #fff3f3;
+  box-shadow: 0 8px 18px rgba(244, 67, 54, 0.15);
+}
+
+.calendar-cell--reserved {
+  padding: 10px 8px;
+}
+
+.reservation-chip {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  border-radius: 16px;
+  background: linear-gradient(135deg, #90caf9 0%, #5c6bc0 100%);
+  color: #fff;
+  padding: 12px;
+  box-shadow: inset 0 2px 6px rgba(255, 255, 255, 0.2), 0 8px 16px rgba(63, 81, 181, 0.2);
+}
+
+.reservation-chip__icon {
+  width: 38px;
+  height: 38px;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.2);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: bold;
+  font-size: 1.1rem;
+}
+
+.reservation-chip__content {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  text-align: left;
+}
+
+.reservation-chip__title {
+  font-size: 1rem;
+  font-weight: 600;
+  line-height: 1.4;
+}
+
+.reservation-chip__meta {
+  font-size: 0.85rem;
+  opacity: 0.85;
+}
+
+.calendar-legend {
+  margin: 16px 0 0;
+  font-size: 0.9rem;
+  color: #546e7a;
+}
+
+.calendar-alert {
+  background: #fff3e0;
+  border-left: 4px solid #ff9800;
+  padding: 12px 16px;
+  border-radius: 12px;
+  color: #e65100;
+}
+
+.calendar-message {
+  min-height: 1.5rem;
+  text-align: center;
+  font-size: 1rem;
+  color: #1a237e;
+  opacity: 0;
+  transition: opacity 0.2s ease;
+}
+
+.calendar-message.is-visible {
+  opacity: 1;
+}
+
+.calendar-message--error {
+  color: #c62828;
+}
+
+.reservation-modal {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.2s ease;
+}
+
+.reservation-modal.is-open {
+  pointer-events: auto;
+  opacity: 1;
+}
+
+.reservation-modal__overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.35);
+}
+
+.reservation-modal__content {
+  position: relative;
+  width: min(420px, 90vw);
+  background: #ffffff;
+  border-radius: 20px;
+  padding: 28px;
+  box-shadow: 0 24px 60px rgba(26, 35, 126, 0.25);
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.reservation-modal__title {
+  margin: 0;
+  font-size: 1.5rem;
+  color: #1a237e;
+}
+
+.reservation-form {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.reservation-form__field {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.reservation-form__label {
+  font-weight: 600;
+  color: #3949ab;
+}
+
+.reservation-form input[type="datetime-local"],
+.reservation-form textarea {
+  width: 100%;
+  padding: 12px 14px;
+  border-radius: 12px;
+  border: 1px solid #c5cae9;
+  font-size: 1rem;
+  font-family: inherit;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.reservation-form input[type="datetime-local"]:focus,
+.reservation-form textarea:focus {
+  outline: none;
+  border-color: #5c6bc0;
+  box-shadow: 0 0 0 3px rgba(92, 107, 192, 0.2);
+}
+
+.reservation-form__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+}
+
+.reservation-button {
+  padding: 0.6rem 1.6rem;
+  border-radius: 999px;
+  border: none;
+  font-weight: 600;
+  cursor: pointer;
+  background: linear-gradient(135deg, #5c6bc0, #3949ab);
+  color: #fff;
+  box-shadow: 0 8px 16px rgba(63, 81, 181, 0.2);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.reservation-button:hover,
+.reservation-button:focus {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 22px rgba(63, 81, 181, 0.26);
+}
+
+.reservation-button--sub {
+  background: #eceff1;
+  color: #37474f;
+  box-shadow: none;
+}
+
+.reservation-button--sub:hover,
+.reservation-button--sub:focus {
+  background: #e0e0e0;
+}
+
+@media (max-width: 768px) {
+  .calendar-controls {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .calendar-controls__buttons {
+    justify-content: center;
+  }
+
+  .calendar-wrapper {
+    padding: 16px;
+  }
+
+  .calendar-cell {
+    height: 64px;
+  }
+
+  .reservation-chip {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}
+
 .home-error small {
   display: block;
   margin-top: 0.5rem;


### PR DESCRIPTION
## Summary
- add a dedicated conference room selection page and update the user home links to point to it
- implement a weekly calendar view for large/small rooms with modal booking and refresh controls
- expose a JSON reservation endpoint and front-end script to submit bookings asynchronously

## Testing
- php -l me.php
- php -l reservations_select.php
- php -l room_calendar.php
- php -l reservation_calendar_api.php

------
https://chatgpt.com/codex/tasks/task_e_68cbb945d2ec8324a0a3837c46225a8d