### PR TITLE
Add admin calendar with PDF support for room reservations

### DIFF
--- a/boranthia.php
+++ b/boranthia.php
@@ -17,7 +17,7 @@ $user = getAuthenticatedUser();
     <h1 class="page-title">地域貢献のお知らせ</h1>
     <div class="user-menu">
       <span class="user-menu__label"><?= htmlspecialchars(($user['display_name'] ?? '') . '（管理者）', ENT_QUOTES, 'UTF-8') ?></span>
-      <a class="user-menu__link" href="reservations.php">会議室予約</a>
+      <a class="user-menu__link" href="admin_calendar.php">会議室予約</a>
       <a class="user-menu__link" href="logout.php">ログアウト</a>
     </div>
   </header>

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -57,6 +57,7 @@ CREATE TABLE IF NOT EXISTS `reservations` (
   `user_id` INT UNSIGNED NOT NULL,
   `reserved_for` VARCHAR(100) NOT NULL,
   `note` TEXT DEFAULT NULL,
+  `document_path` VARCHAR(255) DEFAULT NULL,
   `created_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`),
   UNIQUE KEY `room_datetime_unique` (`room`, `reserved_at`),

--- a/form.php
+++ b/form.php
@@ -17,7 +17,7 @@ $user = getAuthenticatedUser();
     <h1 class="page-title">重要なお知らせ</h1>
     <div class="user-menu">
       <span class="user-menu__label"><?= htmlspecialchars(($user['display_name'] ?? '') . '（' . (($user['role'] ?? '') === 'admin' ? '管理者' : '一般ユーザー') . '）', ENT_QUOTES, 'UTF-8') ?></span>
-      <a class="user-menu__link" href="reservations.php">会議室予約</a>
+      <a class="user-menu__link" href="admin_calendar.php">会議室予約</a>
       <a class="user-menu__link" href="logout.php">ログアウト</a>
     </div>
   </header>

--- a/index.php
+++ b/index.php
@@ -48,7 +48,7 @@ try {
   <header class="home-header">
     <div class="user-menu">
       <span class="user-menu__label">ようこそ、<?= htmlspecialchars($user['display_name'] ?? '', ENT_QUOTES, 'UTF-8') ?>さん（<?= ($user['role'] ?? '') === 'admin' ? '管理者' : '一般ユーザー' ?>）</span>
-      <a class="user-menu__link" href="reservations.php">会議室を予約</a>
+      <a class="user-menu__link" href="admin_calendar.php">会議室を予約</a>
       <a class="user-menu__link" href="logout.php">ログアウト</a>
     </div>
     <h1 class="main-title">お知らせ</h1>
@@ -76,7 +76,7 @@ try {
 
     <section class="cta-section">
       <a href="form.php" class="cta-button">重要なお知らせ一覧を見る</a>
-      <a href="reservations.php" class="cta-button secondary">会議室の予約状況</a>
+      <a href="admin_calendar.php" class="cta-button secondary">会議室の予約状況</a>
     </section>
   </main>
 </body>

--- a/post_form.php
+++ b/post_form.php
@@ -30,7 +30,7 @@ $formTitle = $category['formTitle'];
     <h1 class="page-title">投稿フォーム</h1>
     <div class="user-menu">
       <span class="user-menu__label"><?= htmlspecialchars(($user['display_name'] ?? '') . '（管理者）', ENT_QUOTES, 'UTF-8') ?></span>
-      <a class="user-menu__link" href="reservations.php">会議室予約</a>
+      <a class="user-menu__link" href="admin_calendar.php">会議室予約</a>
       <a class="user-menu__link" href="logout.php">ログアウト</a>
     </div>
   </header>

--- a/reservation_calendar_api.php
+++ b/reservation_calendar_api.php
@@ -77,13 +77,14 @@ if ($errors) {
 
 try {
     $pdo = getPdo();
-    $stmt = $pdo->prepare('INSERT INTO reservations (room, reserved_at, user_id, reserved_for, note) VALUES (:room, :reserved_at, :user_id, :reserved_for, :note)');
+    $stmt = $pdo->prepare('INSERT INTO reservations (room, reserved_at, user_id, reserved_for, note, document_path) VALUES (:room, :reserved_at, :user_id, :reserved_for, :note, :document_path)');
     $stmt->execute([
         ':room' => $room,
         ':reserved_at' => $reservedAt->format('Y-m-d H:i:s'),
         ':user_id' => $user['id'],
         ':reserved_for' => $displayName !== '' ? $displayName : '利用者',
         ':note' => $note !== '' ? $note : null,
+        ':document_path' => null,
     ]);
 
     header('Content-Type: application/json; charset=UTF-8');
@@ -94,6 +95,7 @@ try {
             'reserved_at' => $reservedAt->format('Y-m-d\TH:i'),
             'reserved_for' => $displayName !== '' ? $displayName : '利用者',
             'note' => $note,
+            'document_path' => null,
         ],
         'message' => sprintf('%sを%sに予約しました。', $validRooms[$room], $reservedAt->format('Y/m/d H:i')),
     ]);

--- a/reservations.php
+++ b/reservations.php
@@ -69,7 +69,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 $reservations = [];
 try {
     $pdo = getPdo();
-    $stmt = $pdo->query('SELECT r.id, r.room, r.reserved_at, r.reserved_for, r.note, r.created_at, u.display_name, u.role FROM reservations r INNER JOIN app_users u ON u.id = r.user_id ORDER BY r.reserved_at ASC');
+    $stmt = $pdo->query('SELECT r.id, r.room, r.reserved_at, r.reserved_for, r.note, r.document_path, r.created_at, u.display_name, u.role FROM reservations r INNER JOIN app_users u ON u.id = r.user_id ORDER BY r.reserved_at ASC');
     $reservations = $stmt->fetchAll();
 } catch (Throwable $exception) {
     $errors[] = '予約一覧を取得できませんでした。';
@@ -150,6 +150,9 @@ try {
                 <p>登録者：<?= htmlspecialchars($reservation['display_name'], ENT_QUOTES, 'UTF-8') ?>（<?= $reservation['role'] === 'admin' ? '管理者' : '一般ユーザー' ?>）</p>
                 <?php if (!empty($reservation['note'])): ?>
                   <p>備考：<?= nl2br(htmlspecialchars($reservation['note'], ENT_QUOTES, 'UTF-8')) ?></p>
+                <?php endif; ?>
+                <?php if (!empty($reservation['document_path'])): ?>
+                  <p><a class="reservation-card__attachment" href="<?= htmlspecialchars($reservation['document_path'], ENT_QUOTES, 'UTF-8') ?>" target="_blank" rel="noopener">📄 添付PDFを開く</a></p>
                 <?php endif; ?>
               </div>
             </li>

--- a/room_calendar.php
+++ b/room_calendar.php
@@ -48,7 +48,7 @@ $reservationMap = [];
 $errorMessage = '';
 try {
     $pdo = getPdo();
-    $stmt = $pdo->prepare('SELECT reserved_at, reserved_for, note FROM reservations WHERE room = :room AND reserved_at >= :start AND reserved_at < :end ORDER BY reserved_at');
+    $stmt = $pdo->prepare('SELECT reserved_at, reserved_for, note, document_path FROM reservations WHERE room = :room AND reserved_at >= :start AND reserved_at < :end ORDER BY reserved_at');
     $stmt->execute([
         ':room' => $room,
         ':start' => $weekStart->format('Y-m-d H:i:s'),
@@ -63,6 +63,7 @@ try {
         $reservationMap[$slotKey] = [
             'reserved_for' => $row['reserved_for'],
             'note' => $row['note'] ?? '',
+            'document_path' => $row['document_path'] ?? null,
         ];
     }
 } catch (Throwable $exception) {
@@ -170,6 +171,9 @@ $todayKey = $today->format('Y-m-d');
                       <div class="reservation-chip__content">
                         <span class="reservation-chip__title"><?= htmlspecialchars($note, ENT_QUOTES, 'UTF-8') ?></span>
                         <span class="reservation-chip__meta">担当：<?= htmlspecialchars($reservation['reserved_for'], ENT_QUOTES, 'UTF-8') ?></span>
+                        <?php if (!empty($reservation['document_path'])): ?>
+                          <a class="reservation-chip__attachment" href="<?= htmlspecialchars($reservation['document_path'], ENT_QUOTES, 'UTF-8') ?>" target="_blank" rel="noopener">📄 資料を見る</a>
+                        <?php endif; ?>
                       </div>
                     </div>
                   <?php else: ?>

--- a/sonota.php
+++ b/sonota.php
@@ -17,7 +17,7 @@ $user = getAuthenticatedUser();
     <h1 class="page-title">その他のお知らせ</h1>
     <div class="user-menu">
       <span class="user-menu__label"><?= htmlspecialchars(($user['display_name'] ?? '') . '（' . (($user['role'] ?? '') === 'admin' ? '管理者' : '一般ユーザー') . '）', ENT_QUOTES, 'UTF-8') ?></span>
-      <a class="user-menu__link" href="reservations.php">会議室予約</a>
+      <a class="user-menu__link" href="admin_calendar.php">会議室予約</a>
       <a class="user-menu__link" href="logout.php">ログアウト</a>
     </div>
   </header>

--- a/style.css
+++ b/style.css
@@ -781,6 +781,22 @@ main {
   opacity: 0.85;
 }
 
+.reservation-chip__attachment {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.85rem;
+  color: #e3f2fd;
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+.reservation-chip__attachment:hover,
+.reservation-chip__attachment:focus {
+  color: #bbdefb;
+  text-decoration: underline;
+}
+
 .calendar-legend {
   margin: 16px 0 0;
   font-size: 0.9rem;
@@ -1443,6 +1459,21 @@ main {
   margin: 0.25rem 0;
 }
 
+.reservation-card__attachment {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  color: #2563eb;
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.reservation-card__attachment:hover,
+.reservation-card__attachment:focus {
+  text-decoration: underline;
+  color: #1d4ed8;
+}
+
 .reservation-empty {
   margin: 0;
   color: #607d8b;
@@ -1468,6 +1499,382 @@ main {
   padding: 32px;
   text-align: center;
   box-shadow: var(--shadow-card);
+}
+
+/* =============================
+   管理者カレンダーページ
+   ============================= */
+.page-admin-calendar {
+  min-height: 100vh;
+  background: linear-gradient(180deg, #eef2ff 0%, #f8fbff 100%);
+  color: #1f2937;
+}
+
+.admin-calendar-header {
+  background: linear-gradient(135deg, #4338ca 0%, #2563eb 100%);
+  color: #ffffff;
+  padding: 28px 20px;
+  box-shadow: 0 12px 30px rgba(37, 99, 235, 0.25);
+}
+
+.admin-calendar-header__inner {
+  max-width: 1100px;
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  flex-wrap: wrap;
+}
+
+.admin-calendar-header__titles {
+  flex: 1 1 320px;
+  min-width: 260px;
+}
+
+.admin-calendar-title {
+  margin: 0;
+  font-size: 2.1rem;
+  letter-spacing: 0.04em;
+}
+
+.admin-calendar-subtitle {
+  margin: 8px 0 0;
+  font-size: 1rem;
+  opacity: 0.9;
+}
+
+.admin-calendar-main {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 32px 20px 48px;
+}
+
+.admin-calendar-alert {
+  margin-bottom: 20px;
+  padding: 14px 18px;
+  border-radius: 16px;
+  font-weight: 600;
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.08);
+}
+
+.admin-calendar-alert--success {
+  background: #ecfdf5;
+  color: #047857;
+  border-left: 5px solid #10b981;
+}
+
+.admin-calendar-alert--error {
+  background: #fef2f2;
+  color: #b91c1c;
+  border-left: 5px solid #ef4444;
+}
+
+.admin-calendar-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1.4fr) minmax(0, 1fr);
+  gap: 24px;
+  align-items: flex-start;
+}
+
+.admin-calendar-panel,
+.admin-calendar-details,
+.admin-calendar-form {
+  background: #ffffff;
+  border-radius: 28px;
+  padding: 24px;
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.08);
+}
+
+.admin-calendar-month-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.admin-calendar-month-bar__title {
+  margin: 0;
+  font-size: 1.6rem;
+  color: #1f2937;
+}
+
+.admin-calendar-month-bar__link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 42px;
+  height: 42px;
+  border-radius: 50%;
+  background: #e0e7ff;
+  color: #4338ca;
+  font-size: 1.4rem;
+  text-decoration: none;
+  box-shadow: inset 0 0 0 1px rgba(67, 56, 202, 0.1);
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.admin-calendar-month-bar__link:hover,
+.admin-calendar-month-bar__link:focus {
+  background: #c7d2fe;
+  transform: translateY(-2px);
+}
+
+.admin-calendar-grid {
+  margin-top: 24px;
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.admin-calendar-grid__header {
+  text-align: center;
+  font-weight: 600;
+  color: #4b5563;
+}
+
+.admin-calendar-grid__cell {
+  position: relative;
+  padding: 14px 16px;
+  border-radius: 18px;
+  border: none;
+  background: #eef2ff;
+  color: inherit;
+  min-height: 96px;
+  text-align: left;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
+  box-shadow: inset 0 0 0 1px rgba(67, 56, 202, 0.08);
+}
+
+.admin-calendar-grid__cell:hover,
+.admin-calendar-grid__cell:focus {
+  transform: translateY(-2px);
+  box-shadow: 0 14px 24px rgba(67, 56, 202, 0.18);
+}
+
+.admin-calendar-grid__cell.is-outside {
+  background: #f6f7fb;
+  color: #9ca3af;
+  box-shadow: inset 0 0 0 1px rgba(156, 163, 175, 0.18);
+}
+
+.admin-calendar-grid__cell.has-reservation {
+  box-shadow: inset 0 0 0 2px rgba(37, 99, 235, 0.35);
+}
+
+.admin-calendar-grid__cell.is-selected {
+  background: linear-gradient(135deg, #c7d2fe 0%, #93c5fd 100%);
+  color: #1e3a8a;
+  box-shadow: 0 18px 28px rgba(79, 70, 229, 0.25);
+}
+
+.admin-calendar-grid__date {
+  font-size: 1.15rem;
+  font-weight: 700;
+}
+
+.admin-calendar-grid__badge {
+  margin-top: auto;
+  align-self: flex-start;
+  background: #2563eb;
+  color: #ffffff;
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 4px 10px;
+  border-radius: 999px;
+  box-shadow: 0 6px 12px rgba(37, 99, 235, 0.25);
+}
+
+.admin-calendar-side {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.admin-calendar-details__title,
+.admin-calendar-form__title {
+  margin: 0 0 16px;
+  font-size: 1.3rem;
+  color: #1f2937;
+}
+
+.admin-calendar-details__empty {
+  margin: 0;
+  color: #64748b;
+  background: #f8fafc;
+  border-radius: 16px;
+  padding: 18px;
+}
+
+.admin-calendar-reservations {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.admin-calendar-reservations__item {
+  display: flex;
+  gap: 14px;
+  align-items: flex-start;
+  background: #f8faff;
+  border-radius: 18px;
+  padding: 16px;
+  border: 1px solid rgba(99, 102, 241, 0.18);
+}
+
+.admin-calendar-reservations__time {
+  font-size: 1.15rem;
+  font-weight: 700;
+  color: #4338ca;
+  min-width: 70px;
+}
+
+.admin-calendar-reservations__body {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.admin-calendar-reservations__room {
+  font-weight: 600;
+  color: #1e293b;
+}
+
+.admin-calendar-reservations__meta,
+.admin-calendar-reservations__note {
+  font-size: 0.95rem;
+  color: #475569;
+}
+
+.admin-calendar-reservations__attachment {
+  align-self: flex-start;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-weight: 600;
+  color: #2563eb;
+  text-decoration: none;
+}
+
+.admin-calendar-reservations__attachment:hover,
+.admin-calendar-reservations__attachment:focus {
+  text-decoration: underline;
+  color: #1d4ed8;
+}
+
+.admin-calendar-form__form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.admin-calendar-form__field {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.admin-calendar-form__label {
+  font-weight: 600;
+  color: #1e3a8a;
+}
+
+.admin-calendar-form__form select,
+.admin-calendar-form__form input[type="datetime-local"],
+.admin-calendar-form__form input[type="text"],
+.admin-calendar-form__form textarea {
+  border-radius: 14px;
+  border: 1px solid #c7d2fe;
+  padding: 12px 14px;
+  font-size: 1rem;
+  font-family: inherit;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.admin-calendar-form__form select:focus,
+.admin-calendar-form__form input:focus,
+.admin-calendar-form__form textarea:focus {
+  outline: none;
+  border-color: #6366f1;
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.2);
+}
+
+.admin-calendar-form__hint {
+  color: #64748b;
+  font-size: 0.85rem;
+}
+
+.admin-calendar-pdf {
+  border-radius: 16px;
+  border: 1px solid #dbeafe;
+  background: #f8fbff;
+  padding: 12px;
+}
+
+.admin-calendar-pdf__title {
+  margin: 0 0 8px;
+  font-size: 0.95rem;
+  color: #1e40af;
+}
+
+.admin-calendar-form__actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 4px;
+}
+
+@media (max-width: 1024px) {
+  .admin-calendar-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .admin-calendar-side {
+    flex-direction: column;
+  }
+}
+
+@media (max-width: 768px) {
+  .admin-calendar-header__inner {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .admin-calendar-grid {
+    gap: 10px;
+  }
+
+  .admin-calendar-grid__cell {
+    min-height: 86px;
+  }
+}
+
+@media (max-width: 600px) {
+  .admin-calendar-main {
+    padding: 24px 16px 36px;
+  }
+
+  .admin-calendar-panel,
+  .admin-calendar-details,
+  .admin-calendar-form {
+    padding: 20px;
+    border-radius: 22px;
+  }
+
+  .admin-calendar-grid__cell {
+    padding: 12px;
+  }
+
+  .admin-calendar-reservations__item {
+    flex-direction: column;
+    gap: 10px;
+  }
 }
 
 /* =============================


### PR DESCRIPTION
## Summary
- replace the ad-hoc admin reservation form with a full calendar view that supports PDF uploads and highlights daily bookings
- extend reservation storage and API responses to carry document paths so attachments can be surfaced throughout the UI
- refresh styling and navigation links so admin and room calendars expose attachment links and point to the new calendar experience

## Testing
- php -l admin_calendar.php
- php -l boranthia.php
- php -l form.php
- php -l index.php
- php -l post_form.php
- php -l reservation_calendar_api.php
- php -l reservations.php
- php -l room_calendar.php
- php -l sonota.php

------
https://chatgpt.com/codex/tasks/task_e_68cbdb004a048324b2cec4b458aaafa3