### PR TITLE
Fix deprecated FILTER_SANITIZE_STRING usage in admin calendar

### DIFF
--- a/admin_calendar.php
+++ b/admin_calendar.php
@@ -32,7 +32,7 @@ try {
 
 $monthEnd = $monthStart->modify('+1 month');
 
-$selectedDateParam = filter_input(INPUT_GET, 'selected_date', FILTER_SANITIZE_STRING);
+$selectedDateParam = filter_input(INPUT_GET, 'selected_date', FILTER_UNSAFE_RAW);
 $selectedDate = null;
 if ($selectedDateParam) {
     $candidate = DateTimeImmutable::createFromFormat('Y-m-d', $selectedDateParam, $timezone);


### PR DESCRIPTION
## Summary
- replace the deprecated FILTER_SANITIZE_STRING usage when reading the selected date parameter in the admin calendar

## Testing
- php -l admin_calendar.php

------
https://chatgpt.com/codex/tasks/task_e_68cbdeef43d88324ab1197f15dc02263