### PR TITLE
Add weekday-only calendars with other room and deletion support

### DIFF
--- a/database/schema.sql
+++ b/database/schema.sql
@@ -43,7 +43,7 @@ ON DUPLICATE KEY UPDATE
 
 CREATE TABLE IF NOT EXISTS `reservations` (
   `id` INT UNSIGNED NOT NULL AUTO_INCREMENT,
-  `room` ENUM('large','small') NOT NULL,
+  `room` ENUM('large','small','other') NOT NULL,
   `reserved_at` DATETIME NOT NULL,
   `user_id` INT UNSIGNED NOT NULL,
   `reserved_for` VARCHAR(100) NOT NULL,

--- a/me.php
+++ b/me.php
@@ -13,7 +13,11 @@ if ($isAdmin) {
 
 $displayName = $user['display_name'] ?? '';
 
-$validRooms = ['small' => '小会議室', 'large' => '大会議室'];
+$validRooms = [
+    'small' => '小会議室',
+    'large' => '大会議室',
+    'other' => 'その他',
+];
 $daysOfWeek = [
     1 => '月',
     2 => '火',

--- a/reservation_calendar_api.php
+++ b/reservation_calendar_api.php
@@ -34,7 +34,11 @@ if (stripos($contentType, 'application/json') !== false) {
     $input = $_POST;
 }
 
-$validRooms = ['large' => '大会議室', 'small' => '小会議室'];
+$validRooms = [
+    'large' => '大会議室',
+    'small' => '小会議室',
+    'other' => 'その他',
+];
 $room = isset($input['room']) ? (string) $input['room'] : '';
 $reservedAtInput = isset($input['reserved_at']) ? (string) $input['reserved_at'] : '';
 $note = isset($input['note']) ? trim((string) $input['note']) : '';

--- a/reservation_delete_api.php
+++ b/reservation_delete_api.php
@@ -1,0 +1,91 @@
+<?php
+require_once __DIR__ . '/auth.php';
+require_once __DIR__ . '/database.php';
+require_once __DIR__ . '/reservation_service.php';
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    header('Allow: POST');
+    header('Content-Type: application/json; charset=UTF-8');
+    echo json_encode(['success' => false, 'error' => 'Method not allowed.']);
+    exit;
+}
+
+try {
+    requireLogin();
+} catch (Throwable $exception) {
+    http_response_code(401);
+    header('Content-Type: application/json; charset=UTF-8');
+    echo json_encode(['success' => false, 'error' => '認証が必要です。']);
+    exit;
+}
+
+$user = getAuthenticatedUser();
+
+$input = [];
+$contentType = $_SERVER['CONTENT_TYPE'] ?? '';
+if (stripos($contentType, 'application/json') !== false) {
+    $raw = file_get_contents('php://input');
+    $decoded = json_decode($raw, true);
+    if (is_array($decoded)) {
+        $input = $decoded;
+    }
+} else {
+    $input = $_POST;
+}
+
+$reservationId = isset($input['reservation_id']) ? filter_var($input['reservation_id'], FILTER_VALIDATE_INT) : null;
+if (!$reservationId || $reservationId <= 0) {
+    http_response_code(422);
+    header('Content-Type: application/json; charset=UTF-8');
+    echo json_encode(['success' => false, 'error' => '削除する予約を正しく指定してください。']);
+    exit;
+}
+
+try {
+    $pdo = getPdo();
+    $result = deleteReservation($pdo, $reservationId, $user);
+
+    if (!$result['success']) {
+        $statusCode = 400;
+        if ($result['error_code'] === 'not_found') {
+            $statusCode = 404;
+        } elseif ($result['error_code'] === 'forbidden') {
+            $statusCode = 403;
+        } elseif ($result['error_code'] === 'exception') {
+            $statusCode = 500;
+        }
+        http_response_code($statusCode);
+        header('Content-Type: application/json; charset=UTF-8');
+        echo json_encode([
+            'success' => false,
+            'error' => $result['error'] !== '' ? $result['error'] : '予約を削除できませんでした。',
+        ]);
+        exit;
+    }
+
+    $reservation = $result['reservation'];
+    $validRooms = [
+        'large' => '大会議室',
+        'small' => '小会議室',
+        'other' => 'その他',
+    ];
+
+    $roomLabel = $validRooms[$reservation['room']] ?? $reservation['room'];
+    $reservationDate = DateTimeImmutable::createFromFormat('Y-m-d H:i:s', $reservation['reserved_at'], new DateTimeZone('Asia/Tokyo'));
+    $reservationLabel = $reservationDate instanceof DateTimeImmutable ? $reservationDate->format('Y/m/d H:i') : '';
+    $message = $reservationLabel !== ''
+        ? sprintf('%sの予約（%s）を削除しました。', $roomLabel, $reservationLabel)
+        : sprintf('%sの予約を削除しました。', $roomLabel);
+
+    header('Content-Type: application/json; charset=UTF-8');
+    echo json_encode([
+        'success' => true,
+        'message' => $message,
+        'reservation_id' => $reservationId,
+    ]);
+} catch (Throwable $exception) {
+    http_response_code(500);
+    header('Content-Type: application/json; charset=UTF-8');
+    echo json_encode(['success' => false, 'error' => '予約の削除に失敗しました。時間をおいて再度お試しください。']);
+}

--- a/reservation_service.php
+++ b/reservation_service.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/database.php';
+
+/**
+ * Delete a reservation if the current user has permission.
+ *
+ * @param PDO   $pdo
+ * @param int   $reservationId
+ * @param array $currentUser
+ *
+ * @return array{success:bool,error:string,error_code:?("not_found"|"forbidden"|"exception"),reservation:array|null}
+ */
+function deleteReservation(PDO $pdo, int $reservationId, array $currentUser): array
+{
+    $result = [
+        'success' => false,
+        'error' => '',
+        'error_code' => null,
+        'reservation' => null,
+    ];
+
+    $stmt = $pdo->prepare('SELECT id, room, reserved_at, user_id, document_path FROM reservations WHERE id = :id');
+    $stmt->execute([':id' => $reservationId]);
+    $reservation = $stmt->fetch(PDO::FETCH_ASSOC);
+
+    if (!$reservation) {
+        $result['error'] = '予約が見つかりませんでした。';
+        $result['error_code'] = 'not_found';
+        return $result;
+    }
+
+    $currentUserId = isset($currentUser['id']) ? (int) $currentUser['id'] : 0;
+    $isAdmin = ($currentUser['role'] ?? '') === 'admin';
+
+    if (!$isAdmin && $currentUserId !== (int) $reservation['user_id']) {
+        $result['error'] = 'この予約を削除する権限がありません。';
+        $result['error_code'] = 'forbidden';
+        return $result;
+    }
+
+    $startedTransaction = false;
+
+    try {
+        if (!$pdo->inTransaction()) {
+            $pdo->beginTransaction();
+            $startedTransaction = true;
+        }
+
+        $deleteStmt = $pdo->prepare('DELETE FROM reservations WHERE id = :id');
+        $deleteStmt->execute([':id' => $reservationId]);
+
+        if ($startedTransaction) {
+            $pdo->commit();
+        }
+    } catch (Throwable $exception) {
+        if ($startedTransaction && $pdo->inTransaction()) {
+            $pdo->rollBack();
+        }
+        $result['error'] = '予約の削除に失敗しました。時間をおいて再度お試しください。';
+        $result['error_code'] = 'exception';
+        return $result;
+    }
+
+    if (!empty($reservation['document_path'])) {
+        $filePath = __DIR__ . '/' . ltrim((string) $reservation['document_path'], '/');
+        if (is_file($filePath)) {
+            @unlink($filePath);
+        }
+    }
+
+    $result['success'] = true;
+    $result['reservation'] = $reservation;
+
+    return $result;
+}

--- a/reservations.php
+++ b/reservations.php
@@ -12,7 +12,11 @@ $reservedAtInput = isset($_POST['reserved_at']) ? (string) $_POST['reserved_at']
 $reservedFor = isset($_POST['reserved_for']) ? trim((string) $_POST['reserved_for']) : ($user['display_name'] ?? '');
 $note = isset($_POST['note']) ? trim((string) $_POST['note']) : '';
 
-$validRooms = ['small' => '小会議室', 'large' => '大会議室'];
+$validRooms = [
+    'small' => '小会議室',
+    'large' => '大会議室',
+    'other' => 'その他',
+];
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if (!isset($validRooms[$room])) {

--- a/reservations_select.php
+++ b/reservations_select.php
@@ -17,6 +17,11 @@ $roomPages = [
         'description' => '4〜6名での打ち合わせに最適なコンパクトな会議室です。',
         'link' => 'room_calendar.php?room=small',
     ],
+    'other' => [
+        'label' => 'その他',
+        'description' => 'フリースペースや臨時利用スペースの予定を確認できます。',
+        'link' => 'room_calendar.php?room=other',
+    ],
 ];
 ?>
 <!DOCTYPE html>
@@ -48,7 +53,15 @@ $roomPages = [
       <?php foreach ($roomPages as $roomKey => $room): ?>
         <a class="room-option" role="listitem" href="<?= htmlspecialchars($room['link'], ENT_QUOTES, 'UTF-8') ?>">
           <div class="room-option__icon" aria-hidden="true">
-            <?= $roomKey === 'large' ? '🏢' : '📌' ?>
+            <?php
+              $icon = '📌';
+              if ($roomKey === 'large') {
+                  $icon = '🏢';
+              } elseif ($roomKey === 'other') {
+                  $icon = '🗂️';
+              }
+            ?>
+            <?= $icon ?>
           </div>
           <div class="room-option__content">
             <h3 class="room-option__title"><?= htmlspecialchars($room['label'], ENT_QUOTES, 'UTF-8') ?></h3>

--- a/style.css
+++ b/style.css
@@ -786,6 +786,30 @@ main {
   text-decoration: underline;
 }
 
+.reservation-chip__actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 6px;
+}
+
+.reservation-chip__delete {
+  border: none;
+  border-radius: 999px;
+  padding: 4px 12px;
+  background: rgba(255, 255, 255, 0.22);
+  color: #fff;
+  font-size: 0.78rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.reservation-chip__delete:hover,
+.reservation-chip__delete:focus {
+  background: rgba(255, 255, 255, 0.32);
+  transform: translateY(-1px);
+}
+
 .calendar-legend {
   margin: 16px 0 0;
   font-size: 0.9rem;
@@ -927,6 +951,18 @@ main {
 .reservation-button--sub:hover,
 .reservation-button--sub:focus {
   background: #e0e0e0;
+}
+
+.reservation-button--danger {
+  background: linear-gradient(135deg, #fca5a5, #ef4444);
+  color: #fff;
+  box-shadow: 0 8px 16px rgba(239, 68, 68, 0.18);
+}
+
+.reservation-button--danger:hover,
+.reservation-button--danger:focus {
+  background: linear-gradient(135deg, #f87171, #dc2626);
+  box-shadow: 0 10px 20px rgba(220, 38, 38, 0.25);
 }
 
 @media (max-width: 768px) {
@@ -1612,7 +1648,7 @@ main {
 .admin-calendar-grid {
   margin-top: 24px;
   display: grid;
-  grid-template-columns: repeat(7, minmax(0, 1fr));
+  grid-template-columns: repeat(5, minmax(0, 1fr));
   gap: 14px;
 }
 
@@ -1758,6 +1794,16 @@ main {
   color: #1d4ed8;
 }
 
+.admin-calendar-reservations__actions {
+  margin-top: 10px;
+  display: flex;
+  gap: 12px;
+}
+
+.admin-calendar-reservations__delete-form {
+  margin: 0;
+}
+
 .admin-calendar-form__form {
   display: flex;
   flex-direction: column;
@@ -1836,6 +1882,7 @@ main {
   }
 
   .admin-calendar-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
     gap: 10px;
   }
 
@@ -1854,6 +1901,10 @@ main {
   .admin-calendar-form {
     padding: 20px;
     border-radius: 22px;
+  }
+
+  .admin-calendar-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
   .admin-calendar-grid__cell {


### PR DESCRIPTION
## Summary
- allow the reservations table to store the "その他" room and expose it throughout the reservation selection and listing pages
- update the admin and user-facing calendars to show only weekdays, support deleting reservations, and surface the "その他" room
- add a shared reservation deletion service, JSON API endpoint, and front-end scripting/styles to keep the existing design responsive while enabling the new controls

## Testing
- php -l reservation_service.php
- php -l reservation_delete_api.php
- php -l reservation_calendar_api.php
- php -l reservations.php
- php -l me.php
- php -l reservations_select.php
- php -l room_calendar.php
- php -l admin_calendar.php

------
https://chatgpt.com/codex/tasks/task_e_68ccc16cef588324b7440225e5b3db32