### PR TITLE
Add reserver input to room calendar and update labels

### DIFF
--- a/admin_calendar.php
+++ b/admin_calendar.php
@@ -324,7 +324,7 @@ $selectedDayLabel = $selectedDate->format('Y年n月j日') . '（' . $weekdayLabe
 <body class="page-admin-calendar">
   <header class="admin-calendar-header">
     <div class="admin-calendar-header__inner">
-      <a class="back-link" href="index.php">&larr; 管理トップに戻る</a>
+      <a class="back-link" href="index.php">&larr; 管理ホームに戻る</a>
       <div class="admin-calendar-header__titles">
         <h1 class="admin-calendar-title">予定カレンダー</h1>
         <p class="admin-calendar-subtitle">カレンダーから日付を選んで、PDF資料付きで予定を登録できます。</p>

--- a/calendar.js
+++ b/calendar.js
@@ -4,6 +4,7 @@
   const form = document.getElementById('reservationForm');
   const dateInput = document.getElementById('reservationDateTime');
   const noteInput = document.getElementById('reservationNote');
+  const reservedForInput = document.getElementById('reservationReservedFor');
   const closeButtons = document.querySelectorAll('[data-close-modal]');
   const messageArea = document.querySelector('.calendar-message');
   const refreshButton = document.querySelector('[data-calendar-refresh]');
@@ -15,6 +16,7 @@
   const endpoint = form.dataset.endpoint || form.getAttribute('action') || 'reservation_calendar_api.php';
   const room = form.dataset.room || '';
   const deleteEndpoint = form.dataset.deleteEndpoint || 'reservation_delete_api.php';
+  const defaultReservedFor = form.dataset.defaultReservedFor || '';
   const deleteButtons = document.querySelectorAll('[data-reservation-delete]');
 
   function setMessage(text, isError = false) {
@@ -33,6 +35,9 @@
   function openModal(datetimeValue) {
     dateInput.value = datetimeValue || '';
     noteInput.value = '';
+    if (reservedForInput) {
+      reservedForInput.value = defaultReservedFor;
+    }
     modal.classList.add('is-open');
     modal.setAttribute('aria-hidden', 'false');
     window.setTimeout(() => {
@@ -129,8 +134,13 @@
     event.preventDefault();
     const reservedAt = dateInput.value.trim();
     const note = noteInput.value.trim();
+    const reservedFor = reservedForInput ? reservedForInput.value.trim() : '';
     if (!reservedAt) {
       setMessage('予約日時を入力してください。', true);
+      return;
+    }
+    if (reservedForInput && !reservedFor) {
+      setMessage('予約者を入力してください。', true);
       return;
     }
 
@@ -151,6 +161,7 @@
         body: JSON.stringify({
           room,
           reserved_at: reservedAt,
+          reserved_for: reservedFor,
           note,
         }),
       });

--- a/forbidden.php
+++ b/forbidden.php
@@ -20,7 +20,7 @@ $forbiddenMessage = $forbiddenMessage ?? 'このページにはアクセスで�
     <p><?= nl2br(htmlspecialchars($forbiddenMessage, ENT_QUOTES, 'UTF-8')) ?></p>
     <?php if (isAuthenticated()): ?>
       <div class="cta-section">
-        <a class="cta-button" href="index.php">トップへ戻る</a>
+        <a class="cta-button" href="index.php">ホームに戻る</a>
       </div>
     <?php else: ?>
       <div class="cta-section">

--- a/form.php
+++ b/form.php
@@ -13,7 +13,7 @@ $user = getAuthenticatedUser();
 </head>
 <body class="page-important" data-category="important">
   <header class="page-header">
-    <a class="back-link" href="index.php">&larr; トップへ戻る</a>
+    <a class="back-link" href="index.php">&larr; ホームに戻る</a>
     <h1 class="page-title">重要なお知らせ</h1>
     <div class="user-menu">
       <span class="user-menu__label"><?= htmlspecialchars(($user['display_name'] ?? '') . '（' . (($user['role'] ?? '') === 'admin' ? '管理者' : '一般ユーザー') . '）', ENT_QUOTES, 'UTF-8') ?></span>

--- a/reservation_calendar_api.php
+++ b/reservation_calendar_api.php
@@ -41,6 +41,7 @@ $validRooms = [
 ];
 $room = isset($input['room']) ? (string) $input['room'] : '';
 $reservedAtInput = isset($input['reserved_at']) ? (string) $input['reserved_at'] : '';
+$reservedFor = isset($input['reserved_for']) ? trim((string) $input['reserved_for']) : '';
 $note = isset($input['note']) ? trim((string) $input['note']) : '';
 
 $errors = [];
@@ -72,6 +73,14 @@ if ($reservedAt instanceof DateTimeImmutable) {
     }
 }
 
+if ($reservedFor === '') {
+    if ($displayName !== '') {
+        $reservedFor = $displayName;
+    } else {
+        $errors[] = '予約者を入力してください。';
+    }
+}
+
 if ($errors) {
     http_response_code(422);
     header('Content-Type: application/json; charset=UTF-8');
@@ -86,7 +95,7 @@ try {
         ':room' => $room,
         ':reserved_at' => $reservedAt->format('Y-m-d H:i:s'),
         ':user_id' => $user['id'],
-        ':reserved_for' => $displayName !== '' ? $displayName : '利用者',
+        ':reserved_for' => $reservedFor,
         ':note' => $note !== '' ? $note : null,
         ':document_path' => null,
     ]);
@@ -97,7 +106,7 @@ try {
         'reservation' => [
             'room' => $room,
             'reserved_at' => $reservedAt->format('Y-m-d\TH:i'),
-            'reserved_for' => $displayName !== '' ? $displayName : '利用者',
+            'reserved_for' => $reservedFor,
             'note' => $note,
             'document_path' => null,
         ],

--- a/reservations.php
+++ b/reservations.php
@@ -89,7 +89,7 @@ try {
 </head>
 <body class="page-reservations">
   <header class="page-header">
-    <a class="back-link" href="index.php">&larr; トップへ戻る</a>
+    <a class="back-link" href="index.php">&larr; ホームに戻る</a>
     <h1 class="page-title">会議室予約</h1>
     <div class="user-menu">
       <span class="user-menu__label"><?= htmlspecialchars(($user['display_name'] ?? '') . '（' . ($user['role'] === 'admin' ? '管理者' : '一般ユーザー') . '）', ENT_QUOTES, 'UTF-8') ?></span>

--- a/room_calendar.php
+++ b/room_calendar.php
@@ -177,7 +177,7 @@ $todayKey = $today->format('Y-m-d');
                       <span class="reservation-chip__icon" aria-hidden="true"><?= htmlspecialchars($initial, ENT_QUOTES, 'UTF-8') ?></span>
                       <div class="reservation-chip__content">
                         <span class="reservation-chip__title"><?= htmlspecialchars($note, ENT_QUOTES, 'UTF-8') ?></span>
-                        <span class="reservation-chip__meta">担当：<?= htmlspecialchars($reservation['reserved_for'], ENT_QUOTES, 'UTF-8') ?></span>
+                        <span class="reservation-chip__meta">予約者：<?= htmlspecialchars($reservation['reserved_for'], ENT_QUOTES, 'UTF-8') ?></span>
                         <?php if (!empty($reservation['document_path'])): ?>
                           <a class="reservation-chip__attachment" href="<?= htmlspecialchars($reservation['document_path'], ENT_QUOTES, 'UTF-8') ?>" target="_blank" rel="noopener">📄 資料を見る</a>
                         <?php endif; ?>
@@ -223,10 +223,27 @@ $todayKey = $today->format('Y-m-d');
     <div class="reservation-modal__overlay" data-close-modal></div>
     <div class="reservation-modal__content">
       <h2 class="reservation-modal__title">予約の作成</h2>
-      <form id="reservationForm" class="reservation-form" data-room="<?= htmlspecialchars($room, ENT_QUOTES, 'UTF-8') ?>" data-endpoint="reservation_calendar_api.php" data-delete-endpoint="reservation_delete_api.php">
+      <form
+        id="reservationForm"
+        class="reservation-form"
+        data-room="<?= htmlspecialchars($room, ENT_QUOTES, 'UTF-8') ?>"
+        data-endpoint="reservation_calendar_api.php"
+        data-delete-endpoint="reservation_delete_api.php"
+        data-default-reserved-for="<?= htmlspecialchars($displayName, ENT_QUOTES, 'UTF-8') ?>"
+      >
         <label class="reservation-form__field">
           <span class="reservation-form__label">日時</span>
           <input type="datetime-local" id="reservationDateTime" name="reserved_at" required>
+        </label>
+        <label class="reservation-form__field">
+          <span class="reservation-form__label">予約者</span>
+          <input
+            type="text"
+            id="reservationReservedFor"
+            name="reserved_for"
+            value="<?= htmlspecialchars($displayName, ENT_QUOTES, 'UTF-8') ?>"
+            required
+          >
         </label>
         <label class="reservation-form__field">
           <span class="reservation-form__label">メモ</span>

--- a/sonota.php
+++ b/sonota.php
@@ -13,7 +13,7 @@ $user = getAuthenticatedUser();
 </head>
 <body class="page-contribution" data-category="other">
   <header class="page-header">
-    <a class="back-link" href="index.php">&larr; トップへ戻る</a>
+    <a class="back-link" href="index.php">&larr; ホームに戻る</a>
     <h1 class="page-title">その他のお知らせ</h1>
     <div class="user-menu">
       <span class="user-menu__label"><?= htmlspecialchars(($user['display_name'] ?? '') . '（' . (($user['role'] ?? '') === 'admin' ? '管理者' : '一般ユーザー') . '）', ENT_QUOTES, 'UTF-8') ?></span>


### PR DESCRIPTION
## Summary
- allow specifying a reserver when creating room calendar bookings and show the value in the UI
- rename担当 labels in the room calendar to 予約者 for clarity
- replace "トップへ戻る" style links with "ホームに戻る" (including the admin variant)

## Testing
- php -l room_calendar.php
- php -l reservation_calendar_api.php
- php -l admin_calendar.php
- php -l reservations.php
- php -l form.php
- php -l sonota.php
- php -l forbidden.php

------
https://chatgpt.com/codex/tasks/task_e_68cccaa44d9483249f442d6584726bc9