### PR TITLE
Add logo branding to home and login pages

### DIFF
--- a/index.php
+++ b/index.php
@@ -51,6 +51,9 @@ try {
       <a class="user-menu__link" href="admin_calendar.php">予定を予約</a>
       <a class="user-menu__link" href="logout.php">ログアウト</a>
     </div>
+    <div class="home-logo">
+      <img class="site-logo" src="logo.jpg" alt="T-link ロゴ">
+    </div>
     <h1 class="main-title">お知らせ</h1>
     <nav class="tabs" aria-label="カテゴリ切り替え">
       <?php foreach ($categories as $category): ?>

--- a/login.php
+++ b/login.php
@@ -56,7 +56,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 </head>
 <body class="page-login">
   <main class="login-main">
-    <h1>T-link</h1>
+    <h1 class="login-title">
+      <img class="site-logo login-logo" src="logo.jpg" alt="T-link ロゴ">
+      <span class="visually-hidden">T-link</span>
+    </h1>
     <p class="login-description">管理者は重要・その他のお知らせを投稿でき、一般ユーザーは閲覧と会議室予約が可能です。</p>
     <?php if ($errors): ?>
       <div class="alert alert-error">

--- a/style.css
+++ b/style.css
@@ -28,6 +28,25 @@ main {
   width: 100%;
 }
 
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.site-logo {
+  display: block;
+  width: 100%;
+  max-width: 220px;
+  height: auto;
+}
+
 .page-header {
   width: 100%;
   max-width: 960px;
@@ -297,6 +316,15 @@ main {
   flex-direction: column;
   align-items: center;
   gap: 1rem;
+}
+
+.home-logo {
+  display: flex;
+  justify-content: center;
+}
+
+.home-logo .site-logo {
+  max-width: 260px;
 }
 
 .main-title {
@@ -1471,6 +1499,17 @@ main {
 .login-main h1 {
   margin-top: 0;
   margin-bottom: 0.75rem;
+}
+
+.login-title {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.login-logo {
+  max-width: 200px;
+  margin: 0 auto;
 }
 
 .login-description {


### PR DESCRIPTION
## Summary
- display the new T-link logo in the admin home header while keeping the existing layout
- update the login screen to feature the shared logo with accessible fallback text
- introduce shared styling helpers for the logo and visually hidden text

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cccd5a0b3483249f2abf6a4048ea14